### PR TITLE
Fix application/json typo

### DIFF
--- a/src/routes/(authed)/cases/[caseId]/+page.server.ts
+++ b/src/routes/(authed)/cases/[caseId]/+page.server.ts
@@ -69,7 +69,7 @@ export const actions: Actions = {
 		const res = await event.fetch(`/api/discussions/${form.data.id}`, {
 			method: 'PATCH',
 			body: JSON.stringify({ form, entity: 'cases', entityId: event.params.caseId }),
-			headers: { 'Content-Type': 'appplication/json' }
+			headers: { 'Content-Type': 'application/json' }
 		});
 		const data = await res.json();
 
@@ -88,7 +88,7 @@ export const actions: Actions = {
 		const res = await event.fetch(`/api/discussions`, {
 			method: 'POST',
 			body: JSON.stringify({ form, entity: 'cases', entityId: event.params.caseId }),
-			headers: { 'Content-Type': 'appplication/json' }
+			headers: { 'Content-Type': 'application/json' }
 		});
 
 		const data = await res.json();
@@ -109,7 +109,7 @@ export const actions: Actions = {
 			method: 'POST',
 			body: JSON.stringify({ form, entity: 'cases', entityId: event.params.caseId }),
 			headers: {
-				'Content-Type': 'appplication/json'
+				'Content-Type': 'application/json'
 			}
 		});
 

--- a/src/routes/(authed)/create/+page.server.ts
+++ b/src/routes/(authed)/create/+page.server.ts
@@ -39,7 +39,7 @@ export const actions: Actions = {
 			method: 'POST',
 			body: JSON.stringify({ form }),
 			headers: {
-				'Content-Type': 'appplication/json'
+				'Content-Type': 'application/json'
 			}
 		});
 		const data = await res.json();
@@ -68,7 +68,7 @@ export const actions: Actions = {
 			method: 'POST',
 			body: JSON.stringify({ form }),
 			headers: {
-				'Content-Type': 'appplication/json'
+				'Content-Type': 'application/json'
 			}
 		});
 		const data = await res.json();
@@ -84,7 +84,7 @@ export const actions: Actions = {
 				method: 'POST',
 				body: JSON.stringify({ form: formReason, entity: 'cases', entityId: data.id }),
 				headers: {
-					'Content-Type': 'appplication/json'
+					'Content-Type': 'application/json'
 				}
 			});
 		}

--- a/src/routes/(authed)/policies/[policyId]/editcase/+page.server.ts
+++ b/src/routes/(authed)/policies/[policyId]/editcase/+page.server.ts
@@ -74,7 +74,7 @@ export const actions: Actions = {
 				removedCaseId
 			}),
 			headers: {
-				'Content-Type': 'appplication/json'
+				'Content-Type': 'application/json'
 			}
 		});
 
@@ -103,7 +103,7 @@ export const actions: Actions = {
 			method: 'POST',
 			body: JSON.stringify({ form }),
 			headers: {
-				'Content-Type': 'appplication/json'
+				'Content-Type': 'application/json'
 			}
 		});
 		const data = await res.json();
@@ -121,7 +121,7 @@ export const actions: Actions = {
 				method: 'POST',
 				body: JSON.stringify({ form: formReason, entity: 'cases', entityId: data.id }),
 				headers: {
-					'Content-Type': 'appplication/json'
+					'Content-Type': 'application/json'
 				}
 			});
 			const reasonData = await resReason.json();

--- a/src/routes/(authed)/policies/[policyId]/editpolicy/+page.server.ts
+++ b/src/routes/(authed)/policies/[policyId]/editpolicy/+page.server.ts
@@ -79,7 +79,7 @@ export const actions: Actions = {
 			method: 'PATCH',
 			body: JSON.stringify({ form, action: 'editPolicy' }),
 			headers: {
-				'Content-Type': 'appplication/json'
+				'Content-Type': 'application/json'
 			}
 		});
 


### PR DESCRIPTION
## Summary
- fix typo in Content-Type headers across route handlers

## Testing
- `npm run build` *(fails: "VITE_API_KEY" is not exported)*
- `npm run check` *(fails with type errors)*
- `npm run lint` *(fails due to code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_6840948ae75483329af30df0804c258a