### PR TITLE
Use static adapter and add deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+
+## Deployment
+
+Build the static site and prepare it for deployment with:
+
+```bash
+npm run build
+```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 		"format": "prettier --write ."
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^3.0.0",
+                "@sveltejs/adapter-auto": "^3.0.0",
+                "@sveltejs/adapter-static": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"@types/eslint": "^8.56.7",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -8,10 +8,9 @@ const config = {
 	preprocess: vitePreprocess(),
 
 	kit: {
-		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: adapter()
+               // Using the static adapter to generate a purely static site.
+               // See https://kit.svelte.dev/docs/adapters for more information about adapters.
+               adapter: adapter()
 	}
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,9 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
+const base = process.env.BASE_PATH || '/PolicyCraft/';
+
 export default defineConfig({
-	plugins: [sveltekit()]
+        plugins: [sveltekit()],
+        base
 });


### PR DESCRIPTION
## Summary
- install static adapter dependency
- configure SvelteKit to use adapter-static
- set Vite base path from env or repo path
- document build command for deployment

## Testing
- `npm run lint`
- `npm run check` *(fails: Cannot find package '@sveltejs/adapter-static')*

------
https://chatgpt.com/codex/tasks/task_e_6840948e150883328a09706437f1043f