### PR TITLE
Improve server logging and error handling

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,7 +5,7 @@
 
 import { initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
-// import * as logger from 'firebase-functions/logger';
+import * as logger from 'firebase-functions/logger';
 import { onDocumentCreated } from 'firebase-functions/v2/firestore';
 import { defineString } from 'firebase-functions/params';
 
@@ -24,7 +24,7 @@ const db = getFirestore('policycraft');
 // 	(event) => {
 // 		const snapshot = event.data;
 // 		if (!snapshot) {
-// 			console.log('No data associated with the event');
+// 			logger.warn('No data associated with the event');
 // 			return;
 // 		}
 // 		// Get an object with the current document values.
@@ -61,7 +61,7 @@ exports.policycraftNotificationTrigger = onDocumentCreated(
 	(event) => {
 		const snapshot = event.data;
 		if (!snapshot) {
-			console.log('No data associated with the event');
+			logger.warn('No data associated with the event');
 			return;
 		}
 
@@ -92,11 +92,11 @@ exports.policycraftNotificationTrigger = onDocumentCreated(
 						}
 					} else {
 						// doc.data() will be undefined in this case
-						console.log('No such document!');
+						logger.error('No such document!');
 					}
 				})
 				.catch((error) => {
-					console.log('Error getting document:', error);
+					logger.error('Error getting document:', error);
 				});
 			return;
 		} else if (data.action == 'createComment') {

--- a/src/routes/(authed)/cases/[caseId]/+page.server.ts
+++ b/src/routes/(authed)/cases/[caseId]/+page.server.ts
@@ -26,8 +26,7 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 				dd.id = discussionId;
 				discussions.push(dd);
 			} else {
-				const dd = await response.json();
-				console.log(dd.message);
+				await response.json();
 			}
 		}
 
@@ -39,8 +38,7 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 				rr.id = reasonId;
 				reasons.push(rr);
 			} else {
-				const rr = await response.json();
-				console.log(rr.message);
+				await response.json();
 			}
 		}
 
@@ -71,7 +69,11 @@ export const actions: Actions = {
 			body: JSON.stringify({ form, entity: 'cases', entityId: event.params.caseId }),
 			headers: { 'Content-Type': 'appplication/json' }
 		});
-		const data = await res.json();
+
+		if (!res.ok) {
+			const data = await res.json().catch(() => ({}));
+			return fail(res.status, { form, message: data.message ?? 'Failed to create message' });
+		}
 
 		return {
 			form
@@ -91,7 +93,10 @@ export const actions: Actions = {
 			headers: { 'Content-Type': 'appplication/json' }
 		});
 
-		const data = await res.json();
+		if (!res.ok) {
+			const data = await res.json().catch(() => ({}));
+			return fail(res.status, { form, message: data.message ?? 'Failed to create discussion' });
+		}
 
 		return {
 			form
@@ -105,13 +110,18 @@ export const actions: Actions = {
 			});
 		}
 
-		await event.fetch(`/api/reasons`, {
+		const res = await event.fetch(`/api/reasons`, {
 			method: 'POST',
 			body: JSON.stringify({ form, entity: 'cases', entityId: event.params.caseId }),
 			headers: {
 				'Content-Type': 'appplication/json'
 			}
 		});
+
+		if (!res.ok) {
+			const data = await res.json().catch(() => ({}));
+			return fail(res.status, { form, message: data.message ?? 'Failed to create reason' });
+		}
 
 		return {
 			form

--- a/src/routes/(authed)/policies/[policyId]/+page.server.ts
+++ b/src/routes/(authed)/policies/[policyId]/+page.server.ts
@@ -33,8 +33,7 @@ export const load: PageServerLoad = async ({ params, fetch, locals }) => {
 				cc.reasons = reasons;
 				cases.push(cc);
 			} else {
-				const cc = await response.json();
-				console.log(cc.message);
+				await response.json();
 			}
 		}
 
@@ -46,8 +45,7 @@ export const load: PageServerLoad = async ({ params, fetch, locals }) => {
 				dd.id = discussionId;
 				discussions.push(dd);
 			} else {
-				const dd = await response.json();
-				console.log(dd.message);
+				await response.json();
 			}
 		}
 
@@ -59,8 +57,7 @@ export const load: PageServerLoad = async ({ params, fetch, locals }) => {
 				rr.id = reasonId;
 				reasons.push(rr);
 			} else {
-				const rr = await response.json();
-				console.log(rr.message);
+				await response.json();
 			}
 		}
 
@@ -90,7 +87,11 @@ export const actions: Actions = {
 			method: 'PATCH',
 			body: JSON.stringify({ form, entity: 'policies', entityId: event.params.policyId })
 		});
-		const data = await res.json();
+
+		if (!res.ok) {
+			const data = await res.json().catch(() => ({}));
+			return fail(res.status, { form, message: data.message ?? 'Failed to create message' });
+		}
 
 		return { form };
 	},
@@ -107,7 +108,10 @@ export const actions: Actions = {
 			body: JSON.stringify({ form, entity: 'policies', entityId: event.params.policyId })
 		});
 
-		const data = await res.json();
+		if (!res.ok) {
+			const data = await res.json().catch(() => ({}));
+			return fail(res.status, { form, message: data.message ?? 'Failed to create discussion' });
+		}
 
 		return { form };
 	},
@@ -121,10 +125,15 @@ export const actions: Actions = {
 			return fail(400, form);
 		}
 
-		await event.fetch(`/api/reasons`, {
+		const res = await event.fetch(`/api/reasons`, {
 			method: 'POST',
 			body: JSON.stringify({ form, entity: 'policies', entityId: event.params.policyId })
 		});
+
+		if (!res.ok) {
+			const data = await res.json().catch(() => ({}));
+			return fail(res.status, { form, message: data.message ?? 'Failed to create reason' });
+		}
 
 		return { form };
 	}


### PR DESCRIPTION
## Summary
- replace `console.log` usage in Firebase functions with `firebase-functions/logger`
- remove debug logs from policy and case server pages
- return meaningful error messages from policy and case actions

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840948e322483329a5b0000a74cab0e